### PR TITLE
Added overflow feature to keyboard list handler

### DIFF
--- a/src/react/a11y/README.md
+++ b/src/react/a11y/README.md
@@ -71,6 +71,7 @@ This hook takes two parameters:
     - If this is not defined, home and end buttons will not work
 - `options.enable`: A boolean of if it should be enabled or not
 - `options.runOnIndexChange`: A callback that should be ran whenever the selected index is changed
+- `options.wrapOnOverflow`: A boolean. When false, we force numbers within set min/max constraints, otherwise if true, we allow negative numbers to set the focused index to the minimum and numbers larger than the maximum to set the focused index to the minimum value
 
 #### Run On Index Change Callback
 

--- a/src/react/a11y/__tests__/useKeyboardListNavigation.test.tsx
+++ b/src/react/a11y/__tests__/useKeyboardListNavigation.test.tsx
@@ -2,9 +2,10 @@ import { useKeyboardListNavigation } from "../useKeyboardListNavigation";
 import React, { useRef, useState } from "react";
 import { fireEvent, render } from "@testing-library/react";
 
-test("useKeyboardListNavigation handles everything", async () => {
+const getTestElAndSubmFn = () => {
 	const onSubmit = jest.fn();
-	const TestEl = () => {
+
+	const TestEl = ({ wrapOnOverflow }: { wrapOnOverflow: boolean }) => {
 		const parRef = useRef();
 
 		const valArr = [{ objNum: 1 }, { objNum: 2 }, { objNum: 3 }];
@@ -14,7 +15,8 @@ test("useKeyboardListNavigation handles everything", async () => {
 		const { focusedIndex, selectIndex } = useKeyboardListNavigation(parRef, {
 			maxLength: valArr.length,
 			enable,
-			runOnIndexChange: onSubmit
+			runOnIndexChange: onSubmit,
+			wrapOnOverflow
 		});
 
 		return (
@@ -32,7 +34,18 @@ test("useKeyboardListNavigation handles everything", async () => {
 		);
 	};
 
-	const { findByText, findByTestId } = render(<TestEl />);
+	return {
+		TestEl,
+		onSubmit
+	};
+};
+
+test("useKeyboardListNavigation handles non-overflow behavior", async () => {
+	const { TestEl, onSubmit } = getTestElAndSubmFn();
+
+	const { findByText, findByTestId } = render(
+		<TestEl wrapOnOverflow={false} />
+	);
 
 	expect(await findByText("Focused Index: 0")).toBeInTheDocument();
 
@@ -84,6 +97,65 @@ test("useKeyboardListNavigation handles everything", async () => {
 	fireEvent.click(enableBtn);
 	fireEvent.keyDown(parentEl, { key: "ArrowUp" });
 	expect(await findByText("Focused Index: 2")).toBeInTheDocument();
+
+	// OnSubmit is being called properly
+	expect(onSubmit).lastCalledWith(expect.any(Object), 2, 2);
+});
+
+test("useKeyboardListNavigation handles overflow behavior", async () => {
+	const { TestEl, onSubmit } = getTestElAndSubmFn();
+
+	const { findByText, findByTestId } = render(<TestEl wrapOnOverflow={true} />);
+
+	expect(await findByText("Focused Index: 0")).toBeInTheDocument();
+
+	const selectIndexEl = await findByTestId("selectIndex");
+	const parentEl = await findByTestId("parent");
+	const enableBtn = await findByTestId("enableBtn");
+
+	// Set the value directly
+	fireEvent.change(selectIndexEl, { target: { value: 2 } });
+	expect(await findByText("Focused Index: 2")).toBeInTheDocument();
+
+	// OnSubmit is being called properly
+	expect(onSubmit.mock.calls.length).toBe(1);
+	expect(onSubmit).lastCalledWith(undefined, 0, 2);
+
+	// Should wrap a value that's too low
+	fireEvent.change(selectIndexEl, { target: { value: -1 } });
+	expect(await findByText("Focused Index: 2")).toBeInTheDocument();
+
+	// Should normalize a value that's too high
+	fireEvent.change(selectIndexEl, { target: { value: 3 } });
+	expect(await findByText("Focused Index: 0")).toBeInTheDocument();
+
+	// Arrow down works
+	fireEvent.keyDown(parentEl, { key: "ArrowDown" });
+	expect(await findByText("Focused Index: 1")).toBeInTheDocument();
+
+	// Home should go to zero
+	fireEvent.keyDown(parentEl, { key: "Home" });
+	expect(await findByText("Focused Index: 0")).toBeInTheDocument();
+
+	// Should normalize a value that's too low
+	fireEvent.keyDown(parentEl, { key: "ArrowUp" });
+	expect(await findByText("Focused Index: 2")).toBeInTheDocument();
+
+	fireEvent.keyDown(parentEl, { key: "ArrowUp" });
+	expect(await findByText("Focused Index: 1")).toBeInTheDocument();
+
+	// Key down should work
+	fireEvent.keyDown(parentEl, { key: "ArrowDown" });
+	expect(await findByText("Focused Index: 2")).toBeInTheDocument();
+
+	// Should normalize a value that's too high
+	fireEvent.keyDown(parentEl, { key: "ArrowDown" });
+	expect(await findByText("Focused Index: 0")).toBeInTheDocument();
+
+	// Disable should work
+	fireEvent.click(enableBtn);
+	fireEvent.keyDown(parentEl, { key: "ArrowUp" });
+	expect(await findByText("Focused Index: 0")).toBeInTheDocument();
 
 	// OnSubmit is being called properly
 	expect(onSubmit).lastCalledWith(expect.any(Object), 2, 2);

--- a/src/react/a11y/__tests__/useKeyboardListNavigation.test.tsx
+++ b/src/react/a11y/__tests__/useKeyboardListNavigation.test.tsx
@@ -158,5 +158,5 @@ test("useKeyboardListNavigation handles overflow behavior", async () => {
 	expect(await findByText("Focused Index: 0")).toBeInTheDocument();
 
 	// OnSubmit is being called properly
-	expect(onSubmit).lastCalledWith(expect.any(Object), 2, 2);
+	expect(onSubmit).lastCalledWith(expect.any(Object), 2, 0);
 });

--- a/src/react/a11y/useKeyboardListNavigation.ts
+++ b/src/react/a11y/useKeyboardListNavigation.ts
@@ -34,20 +34,24 @@ export interface UseKeyboardListNavigationOptions {
 	maxLength?: number;
 	enable?: boolean;
 	runOnIndexChange?: UseKeyboardListNavigationSubmitFn;
+	wrapOnOverflow?: boolean;
 }
 
 /**
  * @param parentRef - The parent ref to bind the event handling to
- * @param maxLength - The maximum number that can be bound to
- * @param enable - Disable event handling
- * @param [runOnIndexChange] - An optional function to hook into the event handler logic
+ * @param $1
+ * @param $1.maxLength - The maximum number that can be bound to
+ * @param $1.enable - Disable event handling
+ * @param [$1.wrapOnOverflow] - If true, when max + 1 is reached, go to zero, etc. Defaults false
+ * @param [$1.runOnIndexChange] - An optional function to hook into the event handler logic
  */
 export const useKeyboardListNavigation = (
 	parentRef: RefObject<any>,
 	{
 		maxLength = Infinity,
 		enable = true,
-		runOnIndexChange
+		runOnIndexChange,
+		wrapOnOverflow = false
 	}: UseKeyboardListNavigationOptions
 ) => {
 	const [focusedIndex, setFocusedIndex] = useState(0);
@@ -69,19 +73,11 @@ export const useKeyboardListNavigation = (
 			switch (event.key) {
 				case "ArrowDown":
 					event.preventDefault();
-					if (focusedIndex === maxIndex) {
-						_newIndex = 0;
-					} else {
-						_newIndex = normalizeNumber(focusedIndex + 1, 0, maxIndex);
-					}
+					_newIndex = normalizeNumber(focusedIndex + 1, 0, maxIndex);
 					break;
 				case "ArrowUp":
 					event.preventDefault();
-					if (focusedIndex === 0) {
-						_newIndex = maxIndex;
-					} else {
-						_newIndex = normalizeNumber(focusedIndex - 1, 0, maxIndex);
-					}
+					_newIndex = normalizeNumber(focusedIndex - 1, 0, maxIndex);
 					break;
 				case "Home":
 					event.preventDefault();
@@ -115,7 +111,17 @@ export const useKeyboardListNavigation = (
 	}, [focusedIndex, parentRef, enable, maxIndex, runOnIndexChange]);
 
 	const selectIndex = (i: number, e?: KeyboardSyntheticEvent) => {
-		setFocusedIndex(normalizeNumber(i, 0, maxIndex));
+		if (wrapOnOverflow === true) {
+			if (i < 0) {
+				setFocusedIndex(maxIndex);
+			} else if (i > maxIndex) {
+				setFocusedIndex(0);
+			} else {
+				setFocusedIndex(i);
+			}
+		} else {
+			setFocusedIndex(normalizeNumber(i, 0, maxIndex));
+		}
 
 		if (runOnIndexChange) {
 			if (e && e.persist) e.persist();

--- a/src/react/a11y/useKeyboardListNavigation.ts
+++ b/src/react/a11y/useKeyboardListNavigation.ts
@@ -56,6 +56,7 @@ export const useKeyboardListNavigation = (
 ) => {
 	const [focusedIndex, setFocusedIndex] = useState(0);
 
+	// Select whether to allow wrapping behavior or to restrict index movement within a numerical range
 	const numberValidatrionFn = wrapOnOverflow ? wrapNumber : normalizeNumber;
 
 	const maxIndex = maxLength - 1;

--- a/src/react/a11y/useKeyboardListNavigation.ts
+++ b/src/react/a11y/useKeyboardListNavigation.ts
@@ -69,11 +69,19 @@ export const useKeyboardListNavigation = (
 			switch (event.key) {
 				case "ArrowDown":
 					event.preventDefault();
-					_newIndex = normalizeNumber(focusedIndex + 1, 0, maxIndex);
+					if (focusedIndex === maxIndex) {
+						_newIndex = 0;
+					} else {
+						_newIndex = normalizeNumber(focusedIndex + 1, 0, maxIndex);
+					}
 					break;
 				case "ArrowUp":
 					event.preventDefault();
-					_newIndex = normalizeNumber(focusedIndex - 1, 0, maxIndex);
+					if (focusedIndex === 0) {
+						_newIndex = maxIndex;
+					} else {
+						_newIndex = normalizeNumber(focusedIndex - 1, 0, maxIndex);
+					}
 					break;
 				case "Home":
 					event.preventDefault();

--- a/src/react/a11y/useKeyboardListNavigation.ts
+++ b/src/react/a11y/useKeyboardListNavigation.ts
@@ -57,7 +57,7 @@ export const useKeyboardListNavigation = (
 	const [focusedIndex, setFocusedIndex] = useState(0);
 
 	// Select whether to allow wrapping behavior or to restrict index movement within a numerical range
-	const numberValidatrionFn = wrapOnOverflow ? wrapNumber : normalizeNumber;
+	const numberValidationFn = wrapOnOverflow ? wrapNumber : normalizeNumber;
 
 	const maxIndex = maxLength - 1;
 
@@ -76,11 +76,11 @@ export const useKeyboardListNavigation = (
 			switch (event.key) {
 				case "ArrowDown":
 					event.preventDefault();
-					_newIndex = numberValidatrionFn(focusedIndex + 1, 0, maxIndex);
+					_newIndex = numberValidationFn(focusedIndex + 1, 0, maxIndex);
 					break;
 				case "ArrowUp":
 					event.preventDefault();
-					_newIndex = numberValidatrionFn(focusedIndex - 1, 0, maxIndex);
+					_newIndex = numberValidationFn(focusedIndex - 1, 0, maxIndex);
 					break;
 				case "Home":
 					event.preventDefault();
@@ -114,7 +114,7 @@ export const useKeyboardListNavigation = (
 	}, [focusedIndex, parentRef, enable, maxIndex, runOnIndexChange]);
 
 	const selectIndex = (i: number, e?: KeyboardSyntheticEvent) => {
-		setFocusedIndex(numberValidatrionFn(i, 0, maxIndex));
+		setFocusedIndex(numberValidationFn(i, 0, maxIndex));
 
 		if (runOnIndexChange) {
 			if (e && e.persist) e.persist();

--- a/src/react/a11y/useKeyboardListNavigation.ts
+++ b/src/react/a11y/useKeyboardListNavigation.ts
@@ -17,7 +17,7 @@
  */
 
 import { RefObject, SyntheticEvent, useEffect, useState } from "react";
-import { normalizeNumber } from "../../utils";
+import { normalizeNumber, wrapNumber } from "../../utils";
 
 type KeyboardSyntheticEvent = KeyboardEvent & Partial<SyntheticEvent>;
 
@@ -56,6 +56,8 @@ export const useKeyboardListNavigation = (
 ) => {
 	const [focusedIndex, setFocusedIndex] = useState(0);
 
+	const numberValidatrionFn = wrapOnOverflow ? wrapNumber : normalizeNumber;
+
 	const maxIndex = maxLength - 1;
 
 	// Arrow key handler
@@ -73,11 +75,11 @@ export const useKeyboardListNavigation = (
 			switch (event.key) {
 				case "ArrowDown":
 					event.preventDefault();
-					_newIndex = normalizeNumber(focusedIndex + 1, 0, maxIndex);
+					_newIndex = numberValidatrionFn(focusedIndex + 1, 0, maxIndex);
 					break;
 				case "ArrowUp":
 					event.preventDefault();
-					_newIndex = normalizeNumber(focusedIndex - 1, 0, maxIndex);
+					_newIndex = numberValidatrionFn(focusedIndex - 1, 0, maxIndex);
 					break;
 				case "Home":
 					event.preventDefault();
@@ -111,17 +113,7 @@ export const useKeyboardListNavigation = (
 	}, [focusedIndex, parentRef, enable, maxIndex, runOnIndexChange]);
 
 	const selectIndex = (i: number, e?: KeyboardSyntheticEvent) => {
-		if (wrapOnOverflow === true) {
-			if (i < 0) {
-				setFocusedIndex(maxIndex);
-			} else if (i > maxIndex) {
-				setFocusedIndex(0);
-			} else {
-				setFocusedIndex(i);
-			}
-		} else {
-			setFocusedIndex(normalizeNumber(i, 0, maxIndex));
-		}
+		setFocusedIndex(numberValidatrionFn(i, 0, maxIndex));
 
 		if (runOnIndexChange) {
 			if (e && e.persist) e.persist();

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -8,6 +8,7 @@ Table of Contents
 =================
 
   * [Normalize Number](#normalize-number)
+  * [Wrap Number](#wrap-number)
 
 ------
 
@@ -41,6 +42,38 @@ If the number is more than the maximum, the maximum number will be returned
 normalizeNumber(5, 3, 10); // 5
 normalizeNumber(1, 3, 10); // 3
 normalizeNumber(18, 3, 10); // 10
+```
+
+### Wrap Number
+
+| File               | Function           |
+| ------------------ | ------------------ |
+| `wrap-number` | `wrapNumber`  |
+
+As a result, you're able to import either from:
+```javascript
+import {wrapNumber} from 'batteries-not-included/utils';
+import {wrapNumber} from 'batteries-not-included/utils/wrap-number';
+```
+
+However, due to potential breaking APIs in the future, it is highly suggested to use the first of the two results.
+
+The function takes three parameters:
+
+1) The number to check the value of
+2) The minimum value that the number must be
+3) The maximum value that the number must be
+
+All three of these parameters must be numbers
+
+If the number is less than the minimum, the maximum number will be returned
+If the number is more than the maximum, the minimum number will be returned
+
+#### Examples
+```javascript
+wrapNumber(5, 3, 10); // 5
+wrapNumber(1, 3, 10); // 10
+wrapNumber(18, 3, 10); // 3
 ```
 
 

--- a/src/utils/__tests__/wrap-number.test.ts
+++ b/src/utils/__tests__/wrap-number.test.ts
@@ -1,0 +1,18 @@
+import { wrapNumber } from "../wrap-number";
+
+describe("Wrap number", () => {
+	test("to not wrap a number that is in-range", async () => {
+		const theNum = wrapNumber(5, 3, 10);
+		expect(theNum).toBe(5);
+	});
+
+	test("to wrap a number that is too low", async () => {
+		const theNum = wrapNumber(1, 3, 10);
+		expect(theNum).toBe(10);
+	});
+
+	test("to wrap a number that is too high", async () => {
+		const theNum = wrapNumber(18, 3, 10);
+		expect(theNum).toBe(3);
+	});
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./normalize-number";
 export * from "./tablize";
+export * from "./wrap-number";

--- a/src/utils/wrap-number.ts
+++ b/src/utils/wrap-number.ts
@@ -1,6 +1,6 @@
 /**
  * A function to allow wrapping from the beginning of a series of numbers to the end, and from the end of the series to the beginning.
- * @param {number} numberToNormalize - The number to check
+ * @param {number} numberToWrap - The number to check
  * @param {number} minIndex - This will be returned if the number is lower than it
  * @param {number} maxIndex - This will be returned if the number is higher than it
  * @returns {number}

--- a/src/utils/wrap-number.ts
+++ b/src/utils/wrap-number.ts
@@ -1,0 +1,22 @@
+/**
+ * A function to return a safe value between two ranges.
+ * @param {number} numberToNormalize - The number to check
+ * @param {number} minIndex - This will be returned if the number is lower than it
+ * @param {number} maxIndex - This will be returned if the number is higher than it
+ * @returns {number}
+ */
+export const wrapNumber = (
+	numberToWrap: number,
+	minIndex: number,
+	maxIndex: number
+) => {
+	if (numberToWrap > maxIndex) {
+		return minIndex;
+	}
+
+	if (numberToWrap < minIndex) {
+		return maxIndex;
+	}
+
+	return numberToWrap;
+};

--- a/src/utils/wrap-number.ts
+++ b/src/utils/wrap-number.ts
@@ -1,5 +1,5 @@
 /**
- * A function to return a safe value between two ranges.
+ * A function to allow wrapping from the beginning of a series of numbers to the end, and from the end of the series to the beginning.
  * @param {number} numberToNormalize - The number to check
  * @param {number} minIndex - This will be returned if the number is lower than it
  * @param {number} maxIndex - This will be returned if the number is higher than it


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature: This PR introduces the ability to wrap from the top of a list or menu to the bottom (and vice versa) using keyboard navigation. When at the top of a list, pressing the up arrow will move focus to the last element in the list. When at the end of a list, pressing the down arrow will move focus to the first item in the list.


* **What is the current behavior?** (You can also link to an open issue here)

The current behavior is outlined here:

https://github.com/unicorn-utterances/batteries-not-included/issues/1


* **What is the new behavior (if this is a feature change)?**

In this PR the arrow keys can be used to wrap from top to bottom (and vice versa) if wrapOverflow is enabled. Current functionality is maintained in every respect.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

This PR does not introduce any breaking changes.



* **Other information**:
