### PR TITLE
feat: add working useStableOpts hook and tests

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -73,6 +73,10 @@ export default defineConfig({
             text: "Table",
             link: "/react/table",
           },
+          {
+            text: "Stable Options",
+            link: "/react/stable-options",
+          },
         ],
       },
     ],

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -11,6 +11,8 @@ head:
       content: Simple-to-use React Hooks for RxJS interop.
 ---
 
+# Introduction
+
 We've all been there, using a library we've found that works well for just about every task you throw at it; until it doesn't.
 There's some configuration that the developers have placed in the codebase that prevents you from using it.
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -1,3 +1,5 @@
+# React Utils
+
 As many of these packages are hooks, these packages expect a peer dependency of at least React 16.9.
 
 There are various sub-utilities to the React section of this package:
@@ -9,5 +11,5 @@ There are various sub-utilities to the React section of this package:
 It is suggested that all of these modules are imported from the following:
 
 ```tsx
-import {functionName} from 'batteries-not-included/react';
+import { functionName } from "batteries-not-included/react";
 ```

--- a/docs/react/accessibility.md
+++ b/docs/react/accessibility.md
@@ -1,10 +1,12 @@
+# Accessibility
+
 This set of utilities is meant to help developers create accessible components without making assumptions about how it's UI will display
 
 ## ID Generation
 
-| File       | Function  |
-| ---------- | --------- |
-| `genNewId` | `genId`   |
+| File       | Function |
+| ---------- | -------- |
+| `genNewId` | `genId`  |
 
 This function has no parameters, but will return a number that's unique to that
 instance. We use it to generate new IDs that can be used by an `id` attribute
@@ -21,8 +23,8 @@ this hook may be of help
 
 This hook takes two parameters:
 
-1) `elRef`: A reference to an element used to attach the event listeners to
-2) `options`: An optional object of options for the hook
+1. `elRef`: A reference to an element used to attach the event listeners to
+2. `options`: An optional object of options for the hook
 
 ### Options Object
 
@@ -51,13 +53,13 @@ last index item
 
 This hook takes two parameters:
 
-1) `parentRef`: A reference to an element used to attach the event listeners to
-2) `options`: An optional object of options for the hook
+1. `parentRef`: A reference to an element used to attach the event listeners to
+2. `options`: An optional object of options for the hook
 
 ### Options Object
 
 - `options.maxLength`: The maximum number that should be allowed. By default,
-    - If this is not defined, home and end buttons will not work
+  - If this is not defined, home and end buttons will not work
 - `options.enable`: A boolean of if it should be enabled or not
 - `options.runOnIndexChange`: A callback that should be ran whenever the selected index is changed
 - `options.wrapOnOverflow`: A boolean. When false, we force numbers within set min/max constraints, otherwise if true, we allow negative numbers to set the focused index to the minimum and numbers larger than the maximum to set the focused index to the minimum value
@@ -69,10 +71,10 @@ key listeners to the existing keypress listener, or run other custom
 code when the user changes the index of the currently selected item
 
 - `event`: The keyboard event that's used on the element, useful for extending functionality of the keyboard listener for more keypress checks
-    - Be aware that if you use `selectIndex`, this may be `undefined` if you do not manually pass the keyboard event
+  - Be aware that if you use `selectIndex`, this may be `undefined` if you do not manually pass the keyboard event
 - `focusedIndex`: The previous index that was selected before user interaction
 - `newIndex`: The new index that's now being selected by user interaction
-    - Be aware that this may also be `undefined` if the user selects a key that is not being bound to any specific index value
+  - Be aware that this may also be `undefined` if the user selects a key that is not being bound to any specific index value
 
 It's useful to have both the old and new index for scenarios like allowing
 a user to have a selection that's toggled when the user holds shift and selects two indexes
@@ -83,8 +85,8 @@ The `useKeyboardListNavigation` hook returns an object with two keys:
 
 - `focusedIndex`: The index of the currently focused item
 - `selectIndex`: A function that takes two parameters:
-    1) `index`: The new index that you'd like to have selected
-    2) `event`: The event that was used to trigger the selection. This will get passed to `runOnIndexChange`, so it's suggested to pass it when the user makes keyboard events at least
+  1. `index`: The new index that you'd like to have selected
+  2. `event`: The event that was used to trigger the selection. This will get passed to `runOnIndexChange`, so it's suggested to pass it when the user makes keyboard events at least
 
 ## Selectable Array
 
@@ -98,28 +100,28 @@ useful. This hook assists in scenarios of the sort
 
 This base hook takes two parameters:
 
-1) `valArr`: The original value array that you want to make selectable
-2) `runAfterSelectChange`: An optional function that can be ran after selection changes are made
-    - This is present as the `ref.current` value changes may not trigger a detection change, so this allows you to do so manually
+1. `valArr`: The original value array that you want to make selectable
+2. `runAfterSelectChange`: An optional function that can be ran after selection changes are made
+   - This is present as the `ref.current` value changes may not trigger a detection change, so this allows you to do so manually
 
 ### Returns
 
 This hook returns an object with three keys:
 
 - `internalArr`: An array the same length as `valArr`, but with more metadata on each item in the array
-    - Each item of the array will have the following values:
-        - `id`: A unique ID that can be safely placed in the DOM
-        - `val`: The original value in the `valArr` array
-        - `index`: The original index in the `valArr` array
-        - `selected`: If this item is selected in the data
+  - Each item of the array will have the following values:
+    - `id`: A unique ID that can be safely placed in the DOM
+    - `val`: The original value in the `valArr` array
+    - `index`: The original index in the `valArr` array
+    - `selected`: If this item is selected in the data
 - `selectAll`: A function with no parameters that will mark all items in the array with `selected: true`
 - `markAsSelected`: A function that takes two parameters - a from index and a to index. It will then select all the items from one value to another
-    - If the `from` index is lower than the `to` index, it will simply swap the two numbers and mark the items in between as `selected: true`0
+  - If the `from` index is lower than the `to` index, it will simply swap the two numbers and mark the items in between as `selected: true`0
 
 ## Popover
 
 This hook is meant to provide a utility that can be used to compose functionality
-for a popover component. A popover component is one that has a trigger button and a 
+for a popover component. A popover component is one that has a trigger button and a
 popup after the button is pressed. This hook handles the `expanded` property as well
 as the props to be added to the trigger button
 
@@ -129,9 +131,9 @@ as the props to be added to the trigger button
 
 This hook takes three parameters:
 
-1) `parentRef`: The div that contains the popoverArea and the trigger button
-2) `popoverAreaRef`: The div that will be used as the popover area to focus on when the popover is opened
-3) `options`: An optional object of options for the hook
+1. `parentRef`: The div that contains the popoverArea and the trigger button
+2. `popoverAreaRef`: The div that will be used as the popover area to focus on when the popover is opened
+3. `options`: An optional object of options for the hook
 
 ### Options Object
 
@@ -145,7 +147,7 @@ Because the return object expects you to pass the `buttonProps` `onClick` and `o
 The `usePopover` hook returns an object with three keys:
 
 - `buttonProps`: The set of props that should be expanded on into a button. IE: `<button {...buttonProps}/>`
-    - The two included props in this object are `onClick` and `onKeyDown`. Your own implementations of these will be overwritten if you follow the above code
+  - The two included props in this object are `onClick` and `onKeyDown`. Your own implementations of these will be overwritten if you follow the above code
 - `expanded`: A boolean of if the popover is expanded or not
 - `setExpanded`: A function that takes a single boolean parameter and sets the value of `expanded`
 
@@ -155,15 +157,15 @@ A combobox being a way of selecting multiple items in a list at once, a popover 
 A popup multi-select. This hook is meant to serve as a general utility for multi-select, pop-over combo-box.
 It composes the ability to have a popover, keyboard navigation multi-selects, and tests to see if the user had last used a keyboard
 
-
 | File                 | Function             |
 | -------------------- | -------------------- |
 | `usePopoverCombobox` | `usePopoverCombobox` |
 
 This hook take a single parameter:
-1) An array of values that can be selected that should be used to display the combobox
 
-### Returns 
+1. An array of values that can be selected that should be used to display the combobox
+
+### Returns
 
 The `usePopoverCombobox` hook returns an object with three keys:
 

--- a/docs/react/outside-events.md
+++ b/docs/react/outside-events.md
@@ -1,3 +1,5 @@
+# Outside Events
+
 This set of utilities is meant to track when a user takes an action outside of a given element.
 
 For example, if you want to check when a user is clicking outside of the currently focused element, you'd use `onOutsideClick`
@@ -13,24 +15,25 @@ They're all based on the [onOutsideEvent](./onOutsideEvent.ts) code, which will 
 
 Both of these functions take three parameters:
 
-1) `parentRef`: A reference to the element from a `React.createRef` or `useRef`
-2) `enable`: A boolean to enable/disable the listener
-3) `onOutsideEvent`: A function to run when the outside event is ran
+1. `parentRef`: A reference to the element from a `React.createRef` or `useRef`
+2. `enable`: A boolean to enable/disable the listener
+3. `onOutsideEvent`: A function to run when the outside event is ran
 
 So, for example, you could find yourself with the following code:
+
 ```javascript
 const El = () => {
-    const ref = useRef();
+  const ref = useRef();
 
-    // This will always run becuase of the `true`. You may want to disable
-    // the event listener in some cases, if so then just change `true` to
-    // a changing boolean value
-    useOutsideClick(ref, true, () => {
-      console.log('The user has clicked outside of the div');
-    });
-    
-    return <div ref={ref}/>;
-}
+  // This will always run becuase of the `true`. You may want to disable
+  // the event listener in some cases, if so then just change `true` to
+  // a changing boolean value
+  useOutsideClick(ref, true, () => {
+    console.log("The user has clicked outside of the div");
+  });
+
+  return <div ref={ref} />;
+};
 ```
 
 ## Base Event Listener
@@ -44,8 +47,8 @@ you're able to extend the base code that both of those functions base off of
 
 This base hook takes two parameters:
 
-1) `eventName`: The name of the event in a string for the `document.addEventListener` to attach to
-2) `params`: An array of the three parameters listed for the above usage
+1. `eventName`: The name of the event in a string for the `document.addEventListener` to attach to
+2. `params`: An array of the three parameters listed for the above usage
 
 If you read through the code for any of the hooks that extend the base
 hook, you'll see that writing your own is rather trivial

--- a/docs/react/stable-options.md
+++ b/docs/react/stable-options.md
@@ -1,0 +1,57 @@
+# Stable Options
+
+`useStableOps` allows you to mark some keys in an object as referentially stable, avoiding re-renders.
+
+## Usage
+
+```tsx
+const Child = ({ options }: { options: { a: number } }) => {
+  return <div>{options.a}</div>;
+};
+
+const Parent = () => {
+  const [opts, setOpts] = useState({
+    a: 1,
+  });
+
+  const options = useStableOpts(opts, {
+    unstableKeys: [],
+    stableKeys: ["a"],
+  } as const);
+  return (
+    <div>
+      <Child options={options} />
+      {/* Will not trigger a re-render */}
+      <button onClick={() => setOpts({ a: 2 })}>Change a</button>
+    </div>
+  );
+};
+```
+
+## The Problem We're Solving
+
+Sometimes, in React applications, you need to have an API that accepts an object:
+
+```tsx
+const item = useItem({
+  index: 2,
+  onClick: () => {},
+});
+```
+
+Let's assume we implement this hook like so:
+
+```tsx
+import { useEffect } from "react";
+
+function useItem(opts) {
+  // Pass `opts` to a useEffect here
+  useEffect(() => {
+    // ...
+  }, [opts]);
+}
+```
+
+By doing this, the `useEffect` will always run because the object passed to `useItem` is not [referentially stable](https://unicorn-utterances.com/posts/object-mutation).
+
+To solve this, we wrote `useStableOpts` to allow you to select which keys in the object are stable vs unstable.

--- a/docs/react/table.md
+++ b/docs/react/table.md
@@ -1,6 +1,8 @@
+# Table
+
 This is meant to be a React Table component that is both easy-to-use out-of-the-box, but also extremely configurable without having to eject from the table itself
 
-## Table
+## DataTable
 
 The `DataTable` component handles displaying the `tbody`, `thead`, `tfoot`, and more based on the `DataTableColumn` children passed. It also supports many types of children that aren't column defs, such as [`caption`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption). These other children will be injected below the `thead` and above the `tbody` when supplied
 
@@ -9,9 +11,9 @@ The `DataTable` component handles displaying the `tbody`, `thead`, `tfoot`, and 
 ```typescript jsx
 import { DataTable } from "batteries-not-included/react";
 
-<DataTable items={people} itemKeyGetter={p => p.id}>
-	<caption>This is a test table, please change it before prod</caption>
-	{/* ... */}
+<DataTable items={people} itemKeyGetter={(p) => p.id}>
+  <caption>This is a test table, please change it before prod</caption>
+  {/* ... */}
 </DataTable>;
 ```
 
@@ -47,7 +49,7 @@ import { DataTableColumn } from "batteries-not-included/react";
 | `footer`?   | `({ cIndex: number; columnName: string }) => ReactNode`  | If supplied, will render as the footer element for this specific column. If a single column in a template has a `footer` prop defined, it will generate a `tfoot` element for you, otherwise one will not be supplied |
 | `children`? | `(any, { cIndex: number; rIndex: number }) => ReactNode` | If supplied, will render as the body element for this specific column per-row. Must wrap in `td`. Defaults to: `(val) => <td>{val}</td>`                                                                              |
 
-# Simple Example
+## Simple Example
 
 ```typescript jsx
 import * as React from "react";
@@ -56,32 +58,32 @@ import { render } from "react-dom";
 import { DataTable, DataTableColumn } from "batteries-not-included/react";
 
 const people = [
-	{ name: "Pedro Spencer", age: { val: "25" }, id: 10 },
-	{ name: "Benjamin Auer", age: { val: "12" }, id: 11 },
-	{ name: "Jerome Blick Jr.", age: { val: "35" }, id: 12 },
-	{ name: "Sabryna Friesen", age: { val: "2" }, id: 13 },
-	{ name: "Joel Sauer", age: { val: "28" }, id: 14 },
-	{ name: "Blair Wolff", age: { val: "85" }, id: 15 },
-	{ name: "Constance Yundt", age: { val: "90" }, id: 16 },
-	{ name: "Lourdes Pacocha", age: { val: "56" }, id: 17 },
-	{ name: "Tamia Kshlerin", age: { val: "5" }, id: 18 },
-	{ name: "Willis Tremblay", age: { val: "22" }, id: 19 },
-	{ name: "Sunny Reynolds", age: { val: "11" }, id: 20 }
+  { name: "Pedro Spencer", age: { val: "25" }, id: 10 },
+  { name: "Benjamin Auer", age: { val: "12" }, id: 11 },
+  { name: "Jerome Blick Jr.", age: { val: "35" }, id: 12 },
+  { name: "Sabryna Friesen", age: { val: "2" }, id: 13 },
+  { name: "Joel Sauer", age: { val: "28" }, id: 14 },
+  { name: "Blair Wolff", age: { val: "85" }, id: 15 },
+  { name: "Constance Yundt", age: { val: "90" }, id: 16 },
+  { name: "Lourdes Pacocha", age: { val: "56" }, id: 17 },
+  { name: "Tamia Kshlerin", age: { val: "5" }, id: 18 },
+  { name: "Willis Tremblay", age: { val: "22" }, id: 19 },
+  { name: "Sunny Reynolds", age: { val: "11" }, id: 20 },
 ];
 
 const App = () => {
-	return (
-		<DataTable items={people} itemKeyGetter={p => p.id}>
-			<DataTableColumn name="Name" columnKey="name" />
-			<DataTableColumn name="Age" columnKey="age" />
-		</DataTable>
-	);
+  return (
+    <DataTable items={people} itemKeyGetter={(p) => p.id}>
+      <DataTableColumn name="Name" columnKey="name" />
+      <DataTableColumn name="Age" columnKey="age" />
+    </DataTable>
+  );
 };
 
 render(<App />, document.getElementById("root"));
 ```
 
-# Advanced Example
+## Advanced Example
 
 ```typescript jsx
 import * as React from "react";
@@ -90,68 +92,68 @@ import { render } from "react-dom";
 import { DataTable, DataTableColumn } from "batteries-not-included/react";
 
 const people = [
-	{ name: "Pedro Spencer", age: { val: "25" }, id: 10 },
-	{ name: "Benjamin Auer", age: { val: "12" }, id: 11 },
-	{ name: "Jerome Blick Jr.", age: { val: "35" }, id: 12 },
-	{ name: "Sabryna Friesen", age: { val: "2" }, id: 13 },
-	{ name: "Joel Sauer", age: { val: "28" }, id: 14 },
-	{ name: "Blair Wolff", age: { val: "85" }, id: 15 },
-	{ name: "Constance Yundt", age: { val: "90" }, id: 16 },
-	{ name: "Lourdes Pacocha", age: { val: "56" }, id: 17 },
-	{ name: "Tamia Kshlerin", age: { val: "5" }, id: 18 },
-	{ name: "Willis Tremblay", age: { val: "22" }, id: 19 },
-	{ name: "Sunny Reynolds", age: { val: "11" }, id: 20 }
+  { name: "Pedro Spencer", age: { val: "25" }, id: 10 },
+  { name: "Benjamin Auer", age: { val: "12" }, id: 11 },
+  { name: "Jerome Blick Jr.", age: { val: "35" }, id: 12 },
+  { name: "Sabryna Friesen", age: { val: "2" }, id: 13 },
+  { name: "Joel Sauer", age: { val: "28" }, id: 14 },
+  { name: "Blair Wolff", age: { val: "85" }, id: 15 },
+  { name: "Constance Yundt", age: { val: "90" }, id: 16 },
+  { name: "Lourdes Pacocha", age: { val: "56" }, id: 17 },
+  { name: "Tamia Kshlerin", age: { val: "5" }, id: 18 },
+  { name: "Willis Tremblay", age: { val: "22" }, id: 19 },
+  { name: "Sunny Reynolds", age: { val: "11" }, id: 20 },
 ];
 
 const App = () => {
-	return (
-		<DataTable
-			items={people}
-			itemKeyGetter={p => p.id}
-			trProps={({ rIndex }) => ({
-				onClick: () => {
-					console.log("You clicked on row:", rIndex);
-				}
-			})}
-			tableProps={{ onClick: () => console.log("You clicked on the table") }}
-		>
-			<caption>This is a test table, please change it before prod</caption>
-			<DataTableColumn
-				value={p => p.name}
-				name="Name"
-				columnKey="name"
-				header={name => (
-					<th>
-						<button style={{ background: "black", color: "white" }}>
-							{name}
-						</button>
-					</th>
-				)}
-				footer={({ columnName }) => (
-					<td>
-						<button style={{ background: "red", color: "white" }}>
-							{columnName} Footer!
-						</button>
-					</td>
-				)}
-			/>
-			<DataTableColumn value={p => p.age.val} name="Age" columnKey="age">
-				{(val, meta) => {
-					if (meta.cIndex === 0) {
-						return <th scope="row">{val}</th>;
-					}
+  return (
+    <DataTable
+      items={people}
+      itemKeyGetter={(p) => p.id}
+      trProps={({ rIndex }) => ({
+        onClick: () => {
+          console.log("You clicked on row:", rIndex);
+        },
+      })}
+      tableProps={{ onClick: () => console.log("You clicked on the table") }}
+    >
+      <caption>This is a test table, please change it before prod</caption>
+      <DataTableColumn
+        value={(p) => p.name}
+        name="Name"
+        columnKey="name"
+        header={(name) => (
+          <th>
+            <button style={{ background: "black", color: "white" }}>
+              {name}
+            </button>
+          </th>
+        )}
+        footer={({ columnName }) => (
+          <td>
+            <button style={{ background: "red", color: "white" }}>
+              {columnName} Footer!
+            </button>
+          </td>
+        )}
+      />
+      <DataTableColumn value={(p) => p.age.val} name="Age" columnKey="age">
+        {(val, meta) => {
+          if (meta.cIndex === 0) {
+            return <th scope="row">{val}</th>;
+          }
 
-					return (
-						<td>
-							<button style={{ background: "black", color: "white" }}>
-								Val: {val} Row: {meta.rIndex} Column: {meta.cIndex}
-							</button>
-						</td>
-					);
-				}}
-			</DataTableColumn>
-		</DataTable>
-	);
+          return (
+            <td>
+              <button style={{ background: "black", color: "white" }}>
+                Val: {val} Row: {meta.rIndex} Column: {meta.cIndex}
+              </button>
+            </td>
+          );
+        }}
+      </DataTableColumn>
+    </DataTable>
+  );
 };
 
 render(<App />, document.getElementById("root"));

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,23 +1,25 @@
+# JavaScript Utils
+
 These packages are meant for non-framework based code. This means that every utility in this subpackage should be able to be used
 in vanilla JS or in codebases utilizing something like React or Angular.
 
 ## Normalize Number
 
-| File               | Function           |
-| ------------------ | ------------------ |
-| `normalize-number` | `normalizeNumber`  |
+| File               | Function          |
+| ------------------ | ----------------- |
+| `normalize-number` | `normalizeNumber` |
 
 ```javascript
-import {normalizeNumber} from 'batteries-not-included/utils';
+import { normalizeNumber } from "batteries-not-included/utils";
 ```
 
 However, due to potential breaking APIs in the future, it is highly suggested to use the first of the two results.
 
 The function takes three parameters:
 
-1) The number to check the value of
-2) The minimum value that the number must be
-3) The maximum value that the number must be
+1. The number to check the value of
+2. The minimum value that the number must be
+3. The maximum value that the number must be
 
 All three of these parameters must be numbers
 
@@ -25,6 +27,7 @@ If the number is less than the minimum, the minimum number will be returned
 If the number is more than the maximum, the maximum number will be returned
 
 ### Examples
+
 ```javascript
 normalizeNumber(5, 3, 10); // 5
 normalizeNumber(1, 3, 10); // 3
@@ -33,21 +36,21 @@ normalizeNumber(18, 3, 10); // 10
 
 ## Wrap Number
 
-| File               | Function           |
-| ------------------ | ------------------ |
-| `wrap-number` | `wrapNumber`  |
+| File          | Function     |
+| ------------- | ------------ |
+| `wrap-number` | `wrapNumber` |
 
 ```javascript
-import {wrapNumber} from 'batteries-not-included/utils';
+import { wrapNumber } from "batteries-not-included/utils";
 ```
 
 However, due to potential breaking APIs in the future, it is highly suggested to use the first of the two results.
 
 The function takes three parameters:
 
-1) The number to check the value of
-2) The minimum value that the number must be
-3) The maximum value that the number must be
+1. The number to check the value of
+2. The minimum value that the number must be
+3. The maximum value that the number must be
 
 All three of these parameters must be numbers
 
@@ -55,30 +58,31 @@ If the number is less than the minimum, the maximum number will be returned
 If the number is more than the maximum, the minimum number will be returned
 
 ### Examples
+
 ```javascript
 wrapNumber(5, 3, 10); // 5
 wrapNumber(1, 3, 10); // 10
 wrapNumber(18, 3, 10); // 3
 ```
 
-
 ## Make an ASCII Table From 2D Array
 
-| File      | Function   |
-| --------- | ---------- |
-| `tablize` | `tablize`  |
+| File      | Function  |
+| --------- | --------- |
+| `tablize` | `tablize` |
 
 This function takes a two-dimentional array and treats it as a table,
 so it outputs to a string that's an ASCII art of a table. It will
 treat the first item in the array as a header to said table
 
 For example, given:
+
 ```javascript
 const tableArray = [
-    ["Item", "Count", "Another count"],
-    ["Apples", 3, 1939889988],
-    ["Oranges", 399, 213],
-    ["Bananas", 1, -129389176]
+  ["Item", "Count", "Another count"],
+  ["Apples", 3, 1939889988],
+  ["Oranges", 399, 213],
+  ["Bananas", 1, -129389176],
 ];
 
 console.log(tablize(tableArray));
@@ -100,22 +104,21 @@ Bananas |     1 |    -129389176
 > Also, if you use this for outputting data in Node, you may be better suited
 > by `console.table`, as in some circumstances it is interactive
 
-
 ## Diff An Array
 
-| File                          | Function                   |
-| ----------------------------- | -------------------------- |
-| `get-array-added-and-removed` | `getArrayAddedAndRemoved`  |
+| File                          | Function                  |
+| ----------------------------- | ------------------------- |
+| `get-array-added-and-removed` | `getArrayAddedAndRemoved` |
 
 This function take two arrays and diffs them, telling you what items have been removed from the first array in the second array
 and what items have been added in the second array that wasn't originally in the first array
 
 The function takes three parameters:
 
-1) The old array to compare
-2) The new array to compare
-3) A function that acts as a comparison function. It recieves one item from the old array and one item from the old array and should return a boolean if the two items are the same
+1. The old array to compare
+2. The new array to compare
+3. A function that acts as a comparison function. It recieves one item from the old array and one item from the old array and should return a boolean if the two items are the same
 
 ```javascript
-getArrayAddedAndRemoved([1,2,3], [2,3,4]); // {added: [4], removed: [1]}
+getArrayAddedAndRemoved([1, 2, 3], [2, 3, 4]); // {added: [4], removed: [1]}
 ```

--- a/lib/react/index.ts
+++ b/lib/react/index.ts
@@ -1,3 +1,4 @@
 export * from "./a11y";
 export * from "./outside-events";
 export * from "./table";
+export * from "./stable-options";

--- a/lib/react/stable-options/__tests__/useStableOptions.test-d.ts
+++ b/lib/react/stable-options/__tests__/useStableOptions.test-d.ts
@@ -1,0 +1,91 @@
+import { assertType, it, describe } from "vitest";
+import { useStableOpts } from "../index";
+
+interface PersonOptions {
+  name: string;
+  age: number;
+  speak: () => void;
+}
+
+describe("useStableOpts", () => {
+  it("should be okay when stableKeys has all the keys", () => {
+    const opts = useStableOpts(
+      {
+        name: "bob",
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: ["speak", "age", "name"],
+        unstableKeys: [],
+      } as const
+    );
+
+    assertType<PersonOptions>(opts);
+  });
+
+  it("should be okay when unstableKeys has all the keys", () => {
+    const opts = useStableOpts(
+      {
+        name: "bob",
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: [],
+        unstableKeys: ["name", "age", "speak"],
+      } as const
+    );
+
+    assertType<PersonOptions>(opts);
+  });
+
+  it("should not care what order unstableKeys are in", () => {
+    const opts = useStableOpts(
+      {
+        name: "bob",
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: [],
+        unstableKeys: ["speak", "age", "name"],
+      } as const
+    );
+
+    assertType<PersonOptions>(opts);
+  });
+
+  it("should be fine when all keys are accounted for between two arrays", () => {
+    const opts = useStableOpts(
+      {
+        name: "bob",
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: ["speak", "age"],
+        unstableKeys: ["name"],
+      } as const
+    );
+
+    assertType<PersonOptions>(opts);
+  });
+
+  it("should throw an error when unstable keys does not include one of the keys from the object", () => {
+    const opts = useStableOpts(
+      {
+        name: "bob",
+        age: 12,
+        speak: () => {},
+      },
+      {
+        stableKeys: ["speak", "age"],
+        // @ts-expect-error Missing items
+        unstableKeys: [],
+      } as const
+    );
+
+    assertType<PersonOptions>(opts);
+  });
+});

--- a/lib/react/stable-options/__tests__/useStableOpts.test.tsx
+++ b/lib/react/stable-options/__tests__/useStableOpts.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import React, { useState } from "react";
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useStableOpts } from "../index";
+
+const user = userEvent.setup();
+
+describe("useStableOpts", () => {
+  it("should not re-render keys to stabilize", async () => {
+    const Child = ({ options }: { options: { a: number } }) => {
+      return <div>{options.a}</div>;
+    };
+
+    const Parent = () => {
+      const [opts, setOpts] = useState({
+        a: 1,
+      });
+
+      const options = useStableOpts(opts, {
+        unstableKeys: [],
+        stableKeys: ["a"],
+      } as const);
+      return (
+        <div>
+          <Child options={options} />
+          <button onClick={() => setOpts({ a: 2 })}>Change a</button>
+        </div>
+      );
+    };
+
+    const { getByText } = render(<Parent />);
+    expect(getByText("1")).toBeInTheDocument();
+    await user.click(getByText("Change a"));
+    expect(getByText("1")).toBeInTheDocument();
+  });
+
+  it("should re-render unstable keys", async () => {
+    const Child = ({ options }: { options: { a: () => number } }) => {
+      return <div>{options.a()}</div>;
+    };
+
+    const Parent = () => {
+      const [opts, setOpts] = useState({
+        a: () => 1 as number,
+      });
+
+      const options = useStableOpts(opts, {
+        unstableKeys: ["a"],
+        stableKeys: [],
+      } as const);
+      return (
+        <div>
+          <Child options={options} />
+          <button onClick={() => setOpts({ a: () => 2 })}>Change a</button>
+        </div>
+      );
+    };
+
+    const { getByText } = render(<Parent />);
+    expect(getByText("1")).toBeInTheDocument();
+    await user.click(getByText("Change a"));
+    await waitFor(() => expect(getByText("2")).toBeInTheDocument());
+  });
+});

--- a/lib/react/stable-options/index.ts
+++ b/lib/react/stable-options/index.ts
@@ -1,0 +1,1 @@
+export * from "./useStableOpts";

--- a/lib/react/stable-options/types.ts
+++ b/lib/react/stable-options/types.ts
@@ -1,0 +1,26 @@
+type Contra<T> = T extends any ? (arg: T) => void : never;
+
+type InferContra<T> = [T] extends [(arg: infer I) => void] ? I : never;
+
+/**
+ * "a" | "b" | "c" => "a"
+ */
+type PickOne<T> = InferContra<InferContra<Contra<Contra<T>>>>;
+
+/**
+ * "a" | "b" | "c" => ["a", "b", "c"]
+ */
+export type UnionToTuple<T> = PickOne<T> extends infer U
+  ? Exclude<T, U> extends never
+    ? readonly [T]
+    : readonly [...UnionToTuple<Exclude<T, U>>, U]
+  : never;
+
+/**
+ * "a" | "b" | "c" => ['a', 'b', 'c'] | ['a', 'c', 'b'] | ['b', 'a', 'c'] | ['b', 'c', 'a'] | ['c', 'a', 'b'] | ['c', 'b', 'a'];
+ */
+export type Permutation<T, U = T> = [T] extends readonly [never]
+  ? readonly []
+  : T extends T
+  ? readonly [T, ...Permutation<Exclude<U, T>>]
+  : never;

--- a/lib/react/stable-options/useStableOpts.ts
+++ b/lib/react/stable-options/useStableOpts.ts
@@ -1,0 +1,54 @@
+import { useMemo, useRef } from "react";
+import type { Permutation, UnionToTuple } from "./types";
+
+/**
+ * This allows us to not force our users to `useMemo` the arguments passed to
+ * `useForm`, while also retaining a stable reference to the options object,
+ * except items we expect the user to manually wrap with `useMemo` or
+ * `useCallback`, such as `onSubmit` or similar.
+ * @see https://github.com/TanStack/form/issues/437
+ */
+export function useStableOpts<
+  /**
+   * This complex jumbo of types forces us to pass **every** key from `Opts`,
+   * without any overlap between `ToKeep` and `ToRemove`.
+   */
+  Opts extends object,
+  OptArr extends UnionToTuple<keyof Opts>,
+  ToKeep extends ReadonlyArray<OptArr[keyof OptArr]>,
+  ToRemove extends UnionToTuple<
+    Exclude<keyof Opts, ToKeep[number]>
+  > extends infer U
+    ? U extends readonly [never]
+      ? readonly []
+      : U extends readonly unknown[]
+      ? Permutation<U[number]>
+      : never
+    : never
+>(
+  newOptions: Opts,
+  keyMeta: {
+    stableKeys: ToKeep;
+    unstableKeys: ToRemove;
+  }
+) {
+  const keyMetaRef = useRef(keyMeta);
+  const oldOptions = useRef(newOptions);
+
+  const options = useMemo(() => {
+    let rerender = false;
+    const changedKeys = {} as Partial<Opts>;
+    for (const optKey in newOptions) {
+      const key: keyof typeof newOptions = optKey as never;
+      // Functions must be assigned to `options`
+      if (keyMetaRef.current.stableKeys.includes(key as never)) continue;
+      changedKeys[key] = newOptions[key];
+      rerender = true;
+    }
+    // No change needed, return stable reference
+    if (!rerender) return oldOptions.current;
+    return Object.assign({}, oldOptions.current, changedKeys);
+  }, [newOptions]);
+
+  return options as Opts;
+}


### PR DESCRIPTION
This PR adds a `useStableOpts` hook which may be useful for library authors.

It includes:

- [x] Functionality that's been manually tested
- [x] Integration Tests
- [x] Extremely strict typings
- [x] Type tests
- [x] Initial docs